### PR TITLE
Update collections.yaml

### DIFF
--- a/data/collections.yaml
+++ b/data/collections.yaml
@@ -135,3 +135,12 @@ collections:
       - "wss://nostr.mom/"
       - "wss://relay.primal.net/"
       - "wss://nostr.wine/"
+      - "wss://nostr-01.yakihonne.com/"
+      - "wss://nostr-02.yakihonne.com/"
+      
+  - id: "creations"
+    name: "Creations Feeds"
+    description: "Publish & discover creations: articles, videos, curated collections"
+    relays:
+      - "wss://nostr-01.yakihonne.com/"
+      - "wss://nostr-02.yakihonne.com/"


### PR DESCRIPTION
Adding new collections `creations` for the different types of content existed in nostr: `articles`, `videos`, `curations`.  Adding YakiHonne main relays under the new collection `creations` and under the Global Feeds collection

# Pull Request

## 📝 Changes

- [x] Added new relay
- [x] Added new collection
- [ ] Updated existing data
- [ ] Documentation updates
- [ ] Bug fixes

## 💡 Rationale

**Why this relay/collection?**
**Collection:**
- Not sure about the name (of the collection) we can work around something else if needed I thought about `content` but it seems too vague.
 It would be nice to have a new collection to represent the diversity on Nostr such as: `articles`, `videos`, `curations`.
- Likely to be highly targeted by creators and accelerate adoption.
- Attracts content-driven audiences.
**Relays:**
- YakiHonne has long supported short notes, making it a good fit for Global Feeds thanks to its diverse user base..
- YakiHonne’s main relays have been around for a long time and are widely used by creators of articles, videos, and curated collections.
- The submitted relays provide strong discoverability for creations (articles, videos, curated collections).

## 🤔 Additional Context

Feel free to contact nip-05: redkaz@yakihonne.com for any inquiries.
Thanks.
---

**Checklist before submitting:**

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My changes follow the project's coding style and conventions
- [x] Data validates successfully locally (`npm run validate`)
- [x] The relay meets the selection criteria (stability, accessibility, unique value)
