### PR TITLE
Add 44b relay for content from rising npubs

### DIFF
--- a/data/collections.yaml
+++ b/data/collections.yaml
@@ -75,9 +75,11 @@ collections:
     relays:
       - "wss://relay.nostrzh.org/" # Chinese (pyramid)
       - "wss://yabu.me/" # Japanese (aggregator)
+      - "wss://relay.44billion.net/.well-known/nip50/is:rising/sort:top/language:en" # English (rising)
+      - "wss://relay.44billion.net/.well-known/nip50/is:rising/sort:top/language:pt" # Portuguese (rising)
       - "wss://relay.44billion.net/.well-known/nip50/sort:top/language:en" # English (trending)
-      - "wss://relay.44billion.net/.well-known/nip50/is:popular/language:en" # English (influencers)
       - "wss://relay.44billion.net/.well-known/nip50/sort:top/language:pt" # Portuguese (trending)
+      - "wss://relay.44billion.net/.well-known/nip50/is:popular/language:en" # English (influencers)
       - "wss://relay.44billion.net/.well-known/nip50/is:popular/language:pt" # Portuguese (influencers)
       - "wss://lang.relays.land/af" # Afrikaans
       - "wss://lang.relays.land/ar" # Arabic
@@ -153,4 +155,3 @@ collections:
       - "wss://lang.relays.land/yo" # Yoruba
       - "wss://lang.relays.land/zh" # Chinese
       - "wss://lang.relays.land/zu" # Zulu
-


### PR DESCRIPTION
# Pull Request

## 📝 Changes

- [x] Added new relay
- [ ] Added new collection
- [ ] Updated existing data
- [ ] Documentation updates
- [ ] Bug fixes

## 💡 Rationale

**Why this relay/collection?** (if adding new relay or collection)

Added english and portuguese versions of a relay feed for top content from "rising" pubkeys only,
that is, from users that are not considered influencers yet.

## 🤔 Additional Context

Useful if you're looking for variety on your feed. Context: https://jumble.social/notes/nevent1qvzqqqqqqypzplrsshpc8wn3w3tsf0wpcmhu7latqxt4q809nrz7d3fh4s9n9fxtqyd8wumn8ghj7un9d3shjt35x33xjmrvd9hkutnwv46z7qghwaehxw309aex2mrp0yh8qunfd4skctnwv46z7qpqt46yscgszg9lyysj8ffylv67pvkzfjlwcj99rnyx5lg3lw94y3ss2pjusc

---

**Checklist before submitting:**

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] My changes follow the project's coding style and conventions
- [x] Data validates successfully locally (`npm run validate`)
- [x] The relay meets the selection criteria (stability, accessibility, unique value)
